### PR TITLE
Add options to GetHandlerOptions

### DIFF
--- a/pkg/gcpconnect/json.go
+++ b/pkg/gcpconnect/json.go
@@ -18,6 +18,13 @@ type protoJSONCodec struct {
 	marshalOptions protojson.MarshalOptions
 }
 
+func NewJSONCodec(opts protojson.MarshalOptions) connect.Codec {
+	return &protoJSONCodec{
+		name:           "json",
+		marshalOptions: opts,
+	}
+}
+
 var _ connect.Codec = (*protoJSONCodec)(nil)
 
 func (c *protoJSONCodec) Name() string { return c.name }

--- a/pkg/gcpconnect/option.go
+++ b/pkg/gcpconnect/option.go
@@ -1,0 +1,29 @@
+package gcpconnect
+
+import (
+	"github.com/mycujoo/go-stdlib/pkg/connectlog"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+type Option func(o *options)
+
+type options struct {
+	logOptions     []connectlog.Option
+	marshalOptions protojson.MarshalOptions
+}
+
+// WithLogOptions sets the options for the logging interceptor.
+// E.g. WithLogOptions(connectlog.WithSuccess())
+func WithLogOptions(opts ...connectlog.Option) Option {
+	return func(o *options) {
+		o.logOptions = append(o.logOptions, opts...)
+	}
+}
+
+// WithJSONMarshalOptions sets the marshaling options for the JSON codec.
+// Example: `WithJSONMarshalOptions(protojson.MarshalOptions{EmitUnpopulated: true, UseProtoNames: true})`
+func WithJSONMarshalOptions(opts protojson.MarshalOptions) Option {
+	return func(o *options) {
+		o.marshalOptions = opts
+	}
+}


### PR DESCRIPTION
This would allow us to customize some interceptors.
E.g. in mls-auth I would like to log successful handler calls.